### PR TITLE
Fix the issue that Executioners and Vultures may convert into disabled killer roles.

### DIFF
--- a/src/main/java/org/agmas/noellesroles/Noellesroles.java
+++ b/src/main/java/org/agmas/noellesroles/Noellesroles.java
@@ -380,7 +380,19 @@ public class Noellesroles implements ModInitializer {
                         context.player().addStatusEffect(new StatusEffectInstance(StatusEffects.SLOWNESS, 40, 2));
                         if (vulturePlayerComponent.bodiesEaten >= vulturePlayerComponent.bodiesRequired) {
                             ArrayList<Role> shuffledKillerRoles = new ArrayList<>(WatheRoles.ROLES);
-                            shuffledKillerRoles.removeIf(role -> Harpymodloader.NON_MURDER_ROLES.contains(role) || Harpymodloader.VANNILA_ROLES.contains(role) || !role.canUseKiller() || HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath()));
+                            ArrayList<String> disabledRolePaths = new ArrayList<>(HarpyModLoaderConfig.HANDLER.instance().disabled);
+                            disabledRolePaths.replaceAll(path -> {
+                                int colonIndex = path.lastIndexOf(':');
+                                if (colonIndex == -1) {
+                                    return path;
+                                } else {
+                                    return path.substring(colonIndex + 1);
+                                }
+                            });
+                            shuffledKillerRoles.removeIf(role -> Harpymodloader.NON_MURDER_ROLES.contains(role)
+                                    || Harpymodloader.VANNILA_ROLES.contains(role)
+                                    || !role.canUseKiller()
+                                    || disabledRolePaths.contains(role.identifier().getPath()));
                             if (shuffledKillerRoles.isEmpty()) shuffledKillerRoles.add(WatheRoles.KILLER);
                             Collections.shuffle(shuffledKillerRoles);
 

--- a/src/main/java/org/agmas/noellesroles/mixin/executioner/ExecutionerConfirmMixin.java
+++ b/src/main/java/org/agmas/noellesroles/mixin/executioner/ExecutionerConfirmMixin.java
@@ -45,7 +45,19 @@ public class ExecutionerConfirmMixin {
             if (executionerPlayerComponent.target.equals(victim.getUuid()) && !invalidKill) {
                 executionerPlayerComponent.won = true;
                 ArrayList<Role> shuffledKillerRoles = new ArrayList<>(WatheRoles.ROLES);
-                shuffledKillerRoles.removeIf(role -> Harpymodloader.NON_MURDER_ROLES.contains(role) ||Harpymodloader.VANNILA_ROLES.contains(role) || !role.canUseKiller() || HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath()));
+                ArrayList<String> disabledRolePaths = new ArrayList<>(HarpyModLoaderConfig.HANDLER.instance().disabled);
+                disabledRolePaths.replaceAll(path -> {
+                    int colonIndex = path.lastIndexOf(':');
+                    if (colonIndex == -1) {
+                        return path;
+                    } else {
+                        return path.substring(colonIndex + 1);
+                    }
+                });
+                shuffledKillerRoles.removeIf(role -> Harpymodloader.NON_MURDER_ROLES.contains(role)
+                        || Harpymodloader.VANNILA_ROLES.contains(role)
+                        || !role.canUseKiller()
+                        || disabledRolePaths.contains(role.identifier().getPath()));
                 if (shuffledKillerRoles.isEmpty()) shuffledKillerRoles.add(WatheRoles.KILLER);
                 Collections.shuffle(shuffledKillerRoles);
 


### PR DESCRIPTION
Hi author. While running NoellesRoles on a server _(server QQ chanel 594048732, or organization https://github.com/KaituoDev for more communication)_, we noticed that Executioners and Vultures may convert into disabled killer roles after they achieved their goals.

After observing and testing, we find out that the issue stems from class ExecutionerConfirmMixin.java _(Line 48)_ and class Noellesroles.java _(Line 383)_ :
```
ArrayList<Role> shuffledKillerRoles = new ArrayList<>(WatheRoles.ROLES);
shuffledKillerRoles.removeIf(role -> Harpymodloader.VANNILA_ROLES.contains(role) || !role.canUseKiller() || HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath()));
```

- Role paths gotten by method `role.identifier().getPath()` didn't includes mod namespace:

<img width="414" height="321" alt="职业池" src="https://github.com/user-attachments/assets/719103bb-121f-4861-af92-95adbc9a214b" />

- But some of the disabled role paths gotten by `HarpyModLoaderConfig.HANDLER.instance().disabled` **did** includes mod namespace:
![禁用职业池](https://github.com/user-attachments/assets/f51d6f07-8ee8-42c9-83cc-5b75b10b28c6)

Thats why method `HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath())` dosen't always work.

To solve this problem, before making a comparison, we first disable the mod namespace in the role paths:
```
ArrayList<String> disabledRolePaths = new ArrayList<>(HarpyModLoaderConfig.HANDLER.instance().disabled);
disabledRolePaths.replaceAll(path -> {
    int colonIndex = path.lastIndexOf(':');
    if (colonIndex == -1) {
        return path;
    } else {
       return path.substring(colonIndex + 1);
    }
});
```
We remove disabled roles after that:
```
shuffledKillerRoles.removeIf(role -> Harpymodloader.VANNILA_ROLES.contains(role)
        || !role.canUseKiller()
        || disabledRolePaths.contains(role.identifier().getPath()));
```

In our further tests, we didn't meed this issue again.

Hope this PR could help you fix the issue. We are looking forward to your reply (or disapprove).